### PR TITLE
deepcopy input spec to avoid modifying client object

### DIFF
--- a/data/to_label/stack.json
+++ b/data/to_label/stack.json
@@ -2,5872 +2,2403 @@
     "1": [
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "x": {
-                        "field": "q1", 
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "x"
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "x": {
-                        "field": "q1", 
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "bar", 
+                "encoding": {
+                    "y": {
+                        "sort": "ascending",
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "bar", 
+                "encoding": {
+                    "y": {
+                        "sort": "ascending",
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "bar", 
+                "encoding": {
+                    "y": {
+                        "sort": "ascending",
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
                     }
-                }
-            }, 
-            {
-                "mark": "bar", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }
                 }
             }
         ]
-    ], 
-    "3": [
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "rule", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "sort": "descending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "stdev", 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "rule", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "sort": "descending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "stdev", 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "rule", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "sort": "descending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "stdev", 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "max", 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "x"
-                    }, 
-                    "detail": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "detail"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "aggregate": "max", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "detail": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "detail"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "aggregate": "max", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "detail": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "detail"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "t1", 
-                        "type": "temporal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "sort": "ascending", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "sort": "descending", 
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "sort": "ascending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q2", 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "t1", 
-                        "type": "temporal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "sort": "ascending", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "t1", 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "sort": "ascending", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "opacity": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "opacity"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "opacity": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "opacity": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "opacity": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "stdev", 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "aggregate": "stdev", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "aggregate": "max", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "aggregate": "max", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "aggregate": "max", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": null, 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "color"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }, 
-                    "column": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "column"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "column": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "column"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "column": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "column"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "column": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "column"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "color"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "sort": "descending", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q1", 
-                        "scale": {}, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "sort": "descending", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q1", 
-                        "scale": {}, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "sort": "descending", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q1", 
-                        "scale": {}, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "sort": "descending", 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "area", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "opacity": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "area", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "opacity": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "area", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "opacity": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "area", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "opacity": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ]
-    ], 
+    ],
     "2": [
         [
             {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "x"
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "stack": null,
+                        "field": "n1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "stack": "center",
+                        "field": "n1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
                     "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "field": "n1"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "mean", 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
                     "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
                     "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "sort": "ascending", 
+                        "type": "quantitative",
                         "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": null, 
-                        "channel": "x"
+                            "maxbins": 20
+                        },
+                        "field": "q2"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
                 "encoding": {
-                    "color": {
-                        "sort": "ascending", 
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "quantitative",
                         "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
+                            "maxbins": 20
+                        },
+                        "field": "q2"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
                 "encoding": {
-                    "color": {
-                        "sort": "ascending", 
+                    "x": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "quantitative",
                         "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "center", 
-                        "channel": "x"
+                            "maxbins": 20
+                        },
+                        "stack": "center",
+                        "field": "q2"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
                 "encoding": {
-                    "color": {
-                        "sort": "ascending", 
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "quantitative",
                         "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "x"
+                            "maxbins": 20
+                        },
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "area", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "field": "q1", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "x"
+                        },
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "ordinal",
+                        "stack": null,
+                        "field": "o1"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "area", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "field": "q1", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {}, 
-                        "field": "o1", 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        },
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "ordinal",
+                        "field": "o1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "area", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "field": "q1", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {}, 
-                        "field": "o1", 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "x"
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "ordinal",
+                        "field": "o1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "ordinal",
+                        "stack": "normalize",
+                        "field": "o1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
+                "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "bin": {
+                            "maxbins": 5
+                        },
+                        "stack": null,
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "point", 
+                "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "bin": {
+                            "maxbins": 5
+                        },
+                        "field": "q2"
+                    }
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "point", 
+                "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "bin": {
+                            "maxbins": 5
+                        },
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "point", 
+                "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "bin": {
+                            "maxbins": 5
+                        },
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "aggregate": "mean", 
-                        "field": "q1", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
+                        },
+                        "sort": "ascending",
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
                     "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": null, 
-                        "channel": "y"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "aggregate": "mean", 
-                        "field": "q1", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
+                        },
+                        "sort": "ascending",
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "aggregate": "mean", 
-                        "field": "q1", 
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "y"
+                        },
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "sort": "ascending", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q2", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
+                        },
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "sort": "ascending", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q2", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
+                        },
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "sort": "ascending", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q2", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
+                        },
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "sort": "ascending", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "q2", 
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
+                        },
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "field": "q1", 
+                    "x": {
+                        "type": "nominal",
+                        "stack": null,
+                        "field": "n1"
+                    },
+                    "y": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": null, 
-                        "channel": "y"
+                        },
+                        "stack": "zero",
+                        "type": "quantitative",
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "field": "q1", 
+                    "x": {
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    },
+                    "y": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "zero", 
-                        "channel": "y"
+                        },
+                        "stack": "zero",
+                        "type": "quantitative",
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "field": "q1", 
+                    "x": {
+                        "type": "nominal",
+                        "stack": "center",
+                        "field": "n1"
+                    },
+                    "y": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "center", 
-                        "channel": "y"
+                        },
+                        "stack": "zero",
+                        "type": "quantitative",
+                        "field": "q1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "color": {
-                        "field": "q1", 
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "y"
+                        },
+                        "stack": "normalize",
+                        "type": "quantitative",
+                        "field": "q1"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "x"
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q2"
                     }
-                }
-            }, 
-            {
-                "mark": "line", 
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "line", 
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "line", 
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "line", 
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "line", 
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "rect", 
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "aggregate": "mean",
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": null,
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "center",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "x": {
+                        "aggregate": "sum",
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "aggregate": "sum",
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "aggregate": "sum",
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "x": {
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "sort": "ascending",
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "x": {
+                        "sort": "ascending",
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "sort": "ascending",
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "y": {
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
                 "scale": {
                     "zero": true
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "rect", 
+                },
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
                 "scale": {
                     "zero": true
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "rect", 
+                },
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
                 "scale": {
                     "zero": true
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "rect", 
+                },
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "scale": {
-                    "zero": true
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "opacity": {
+                        "type": "quantitative",
+                        "field": "q2"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
+                    "opacity": {
+                        "type": "quantitative",
+                        "field": "q2"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
+                    "opacity": {
+                        "type": "quantitative",
+                        "field": "q2"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "field": "q1", 
+                    "x": {
+                        "aggregate": "min",
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
+                        },
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
                     }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "field": "q1", 
+                    "x": {
+                        "aggregate": "min",
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        },
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": "center",
+                        "field": "n1"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "tick", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "field": "q1", 
+                    "x": {
+                        "aggregate": "mean",
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
+                        },
+                        "sort": "descending",
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
                     }
-                }
-            }, 
-            {
-                "mark": "tick", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "x": {
-                        "sort": "descending", 
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
                     "x": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "x": {
-                        "sort": "descending", 
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
-            }, 
+            },
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
                     "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "y"
-                    }, 
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
                     "x": {
-                        "sort": "descending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
                     }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
                     "y": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q2", 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
+                        "type": "nominal",
+                        "stack": null,
+                        "field": "n1"
                     }
-                }
-            }, 
-            {
-                "mark": "bar", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
                 "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
                     "y": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q2", 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
+                        "type": "nominal",
+                        "field": "n1"
                     }
-                }
-            }, 
-            {
-                "mark": "bar", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q2", 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "bar", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q2", 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }
                 }
             }
         ]
-    ], 
+    ],
+    "3": [
+        [
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": null,
+                        "field": "n1"
+                    },
+                    "y": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "opacity": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "opacity": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "center",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "opacity": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "opacity": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "opacity": {
+                        "type": "quantitative",
+                        "bin": {
+                            "maxbins": 5
+                        },
+                        "field": "q1"
+                    },
+                    "y": {
+                        "sort": "descending",
+                        "type": "nominal",
+                        "stack": null,
+                        "field": "n1"
+                    },
+                    "x": {
+                        "aggregate": "mean",
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "opacity": {
+                        "type": "quantitative",
+                        "bin": {
+                            "maxbins": 5
+                        },
+                        "field": "q1"
+                    },
+                    "y": {
+                        "sort": "descending",
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
+                    },
+                    "x": {
+                        "aggregate": "mean",
+                        "type": "quantitative",
+                        "field": "q2"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "row": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n2"
+                    },
+                    "x": {
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "row": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n2"
+                    },
+                    "x": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o2"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "ordinal",
+                        "stack": "zero",
+                        "field": "o1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o2"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o2"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "ordinal",
+                        "stack": "normalize",
+                        "field": "o1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": null,
+                        "field": "n1"
+                    },
+                    "column": {
+                        "type": "nominal",
+                        "field": "n2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "column": {
+                        "type": "nominal",
+                        "field": "n2"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "column": {
+                        "type": "nominal",
+                        "field": "n2"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "row": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "field": "n1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "row": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "row": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": "center",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "row": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "nominal",
+                        "stack": "normalize",
+                        "field": "n1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q2"
+                    },
+                    "column": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q2"
+                    },
+                    "column": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q2"
+                    },
+                    "column": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ],
+        [
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "stack": "zero",
+                        "field": "n1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "aggregate": "mean",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "stack": "center",
+                        "field": "n1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "bar",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            },
+            {
+                "encoding": {
+                    "y": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "normalize",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
+                    "opacity": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "area",
+                "data": {
+                    "url": "data/cars_mod.json"
+                }
+            }
+        ]
+    ],
     "4": [
         [
             {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "column": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "column"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "bin": {
-                            "maxbins": 100
-                        }, 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "column": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "column"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "bin": {
-                            "maxbins": 100
-                        }, 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "column": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "column"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "bin": {
-                            "maxbins": 100
-                        }, 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "scale": {}, 
-                        "field": "q1", 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "size"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q1", 
-                        "scale": {}, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "size"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q1", 
-                        "scale": {}, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "center", 
-                        "channel": "size"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "bin": {
-                            "maxbins": 3
-                        }, 
-                        "field": "q1", 
-                        "scale": {}, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "size": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "size"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "color"
-                    }, 
-                    "detail": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "detail"
-                    }, 
-                    "x": {
-                        "aggregate": "mean", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "detail": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "detail"
-                    }, 
-                    "x": {
-                        "aggregate": "mean", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "detail": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "detail"
-                    }, 
-                    "x": {
-                        "aggregate": "mean", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "mean", 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "detail": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "detail"
-                    }, 
-                    "color": {
-                        "sort": "ascending", 
-                        "bin": {
-                            "maxbins": 10
-                        }, 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q2", 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q1", 
-                        "aggregate": "mean", 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "detail": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "detail"
-                    }, 
-                    "color": {
-                        "sort": "ascending", 
-                        "bin": {
-                            "maxbins": 10
-                        }, 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "field": "q2", 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "x"
-                    }, 
-                    "shape": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "shape"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "shape": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "shape"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "x"
-                    }, 
-                    "shape": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "shape"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "shape": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "shape"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
                     "opacity": {
-                        "field": "q3", 
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "quantitative",
+                        "field": "q2"
+                    },
+                    "x": {
                         "scale": {
                             "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
+                        },
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q3"
+                    },
                     "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "color"
+                        "type": "ordinal",
+                        "field": "o1"
                     }
-                }
-            }, 
-            {
-                "mark": "line", 
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
-                    }, 
-                    "opacity": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }
                 }
-            }, 
+            },
             {
-                "mark": "line", 
+                "encoding": {
+                    "opacity": {
+                        "type": "quantitative",
+                        "field": "q1"
+                    },
+                    "y": {
+                        "type": "quantitative",
+                        "field": "q2"
+                    },
+                    "x": {
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "stack": "center",
+                        "field": "q3"
+                    },
+                    "color": {
+                        "type": "ordinal",
+                        "field": "o1"
+                    }
+                },
+                "mark": "area",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "aggregate": "mean", 
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "opacity": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "y": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "sort": "ascending", 
-                        "scale": {}, 
-                        "field": "n1", 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "opacity": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "opacity"
-                    }, 
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "color"
-                    }
                 }
             }
-        ], 
+        ],
         [
             {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
                 "encoding": {
+                    "y": {
+                        "type": "quantitative",
+                        "stack": null,
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
                     "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    },
                     "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "opacity"
-                    }, 
-                    "y": {
-                        "field": "n3", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": null, 
-                        "channel": "x"
+                        "type": "quantitative",
+                        "field": "q3"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
+                }
+            },
+            {
                 "encoding": {
+                    "y": {
+                        "type": "quantitative",
+                        "stack": "zero",
+                        "field": "q1"
+                    },
+                    "x": {
+                        "type": "nominal",
+                        "field": "n1"
+                    },
                     "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
+                        "scale": {
+                            "zero": true
+                        },
+                        "type": "quantitative",
+                        "field": "q2"
+                    },
                     "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "opacity"
-                    }, 
-                    "y": {
-                        "field": "n3", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "x"
+                        "type": "quantitative",
+                        "field": "q3"
                     }
-                }
-            }, 
-            {
-                "mark": "point", 
+                },
+                "mark": "bar",
                 "data": {
                     "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "opacity"
-                    }, 
-                    "y": {
-                        "field": "n3", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "opacity": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "opacity"
-                    }, 
-                    "y": {
-                        "field": "n3", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "y"
-                    }, 
-                    "x": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "stack": null, 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "t1", 
-                        "scale": {}, 
-                        "type": "temporal", 
-                        "channel": "size"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "row": {
-                        "sort": "ascending", 
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "row"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "row": {
-                        "sort": "ascending", 
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "row"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "row": {
-                        "sort": "ascending", 
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "row"
-                    }
-                }
-            }, 
-            {
-                "mark": "line", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q3", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "row": {
-                        "sort": "ascending", 
-                        "field": "o1", 
-                        "scale": {}, 
-                        "type": "ordinal", 
-                        "channel": "row"
-                    }
-                }
-            }
-        ], 
-        [
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": null, 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "zero", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "center", 
-                        "channel": "size"
-                    }
-                }
-            }, 
-            {
-                "mark": "point", 
-                "data": {
-                    "url": "data/cars_mod.json"
-                }, 
-                "encoding": {
-                    "color": {
-                        "field": "n2", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "channel": "color"
-                    }, 
-                    "x": {
-                        "field": "n1", 
-                        "scale": {}, 
-                        "type": "nominal", 
-                        "stack": "zero", 
-                        "channel": "x"
-                    }, 
-                    "y": {
-                        "field": "q2", 
-                        "scale": {
-                            "zero": true, 
-                            "type": "log"
-                        }, 
-                        "type": "quantitative", 
-                        "stack": "normalize", 
-                        "channel": "y"
-                    }, 
-                    "size": {
-                        "field": "q1", 
-                        "scale": {
-                            "zero": true
-                        }, 
-                        "type": "quantitative", 
-                        "channel": "size"
-                    }
                 }
             }
         ]

--- a/draco/generation/define/distributions.json
+++ b/draco/generation/define/distributions.json
@@ -60,10 +60,10 @@
     ]
   },
   "scale": {
-    "probability": 0.5,
+    "probability": 0.1,
     "values": [
-      { "name": "zero", "probability": 0.9},
-      { "name": "log", "probability": 0.1 }
+      { "name": "zero", "probability": 0.5 },
+      { "name": "log", "probability": 0.5 }
     ]
   },
   "timeUnit": {

--- a/draco/generation/generator.py
+++ b/draco/generation/generator.py
@@ -20,13 +20,13 @@ class Generator:
         base_spec = self.model.generate_spec(dimensions)
 
         specs = []
-        self.__mutate_spec(base_spec, props.copy(), specs, set())
+        self.__mutate_spec(base_spec, props, 0, set(), specs)
         return specs
 
 
-    def __mutate_spec(self, base_spec, props, specs, seen):
-        if (not props):
-            self.model.improve(base_spec)
+    def __mutate_spec(self, base_spec, props, prop_index, seen, specs):
+        if (prop_index == len(props)):
+            self.model.improve(base_spec, props)
 
             if not (base_spec in seen):
                 seen.add(base_spec)
@@ -38,12 +38,12 @@ class Generator:
                     base_spec['data'] = { 'url': self.data_url }
                     specs.append(base_spec)
         else:
-            prop_to_mutate = props.pop(0)
+            prop_to_mutate = props[prop_index]
             for enum in self.model.get_enums(prop_to_mutate):
                 spec = deepcopy(base_spec)
                 self.model.mutate_prop(spec, prop_to_mutate, enum)
 
-                self.__mutate_spec(spec, props, specs, seen)
+                self.__mutate_spec(spec, props, prop_index + 1, seen, specs)
 
         return
 

--- a/draco/generation/helper.py
+++ b/draco/generation/helper.py
@@ -4,13 +4,13 @@ from draco.run import run_draco
 from draco.spec import Task
 
 
-def is_valid(task: Task) -> bool:
+def is_valid(task: Task, debug=False) -> bool:
     ''' Check a task.
         Args:
             task: a task spec object
         Returns:
             whether the task is valid
     '''
-    _, stdout = run_draco(task, files=['define.lp', 'test.lp'], silence_warnings=True)
+    _, stdout = run_draco(task, files=['define.lp', 'test.lp'], silence_warnings=True, debug=debug)
 
     return json.loads(stdout)['Result'] != 'UNSATISFIABLE'

--- a/draco/generation/run.py
+++ b/draco/generation/run.py
@@ -17,7 +17,7 @@ INTERACTIONS_PATH = absolute_path('define/interactions.json')
 DISTRIBUTIONS_PATH = absolute_path('define/distributions.json')
 DEFINITIONS_PATH = absolute_path('define/definitions.json')
 DUMMY_SCHEMA_PATH = absolute_path('define/dummy_schema.json')
-DATA_URL = 'data/random_data.json'
+DATA_URL = 'data/cars_mod.json'
 
 NUM_TRIES = 100
 MAX_DIMENSIONS = 4
@@ -74,7 +74,7 @@ def load_json(file_path):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--interaction', '-i', default='all')
-    parser.add_argument('--groups', '-g', default=20)
+    parser.add_argument('--groups', '-g', default=40)
     parser.add_argument('--output_dir', '-o', default=absolute_path('../../data/to_label'))
 
     args = parser.parse_args()

--- a/draco/spec.py
+++ b/draco/spec.py
@@ -6,7 +6,6 @@ import json
 import os
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
-from copy import deepcopy
 
 import agate
 import numpy as np
@@ -482,8 +481,6 @@ class Query():
     @staticmethod
     def from_vegalite(full_spec: Dict) -> 'Query':
         ''' Parse from Vega-Lite spec that uses map for encoding. '''
-        full_spec = deepcopy(full_spec)
-
         encodings: List[Encoding] = []
 
         for channel, enc in full_spec.get('encoding', {}).items():

--- a/draco/spec.py
+++ b/draco/spec.py
@@ -6,6 +6,7 @@ import json
 import os
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from copy import deepcopy
 
 import agate
 import numpy as np
@@ -481,6 +482,8 @@ class Query():
     @staticmethod
     def from_vegalite(full_spec: Dict) -> 'Query':
         ''' Parse from Vega-Lite spec that uses map for encoding. '''
+        full_spec = deepcopy(full_spec)
+
         encodings: List[Encoding] = []
 
         for channel, enc in full_spec.get('encoding', {}).items():

--- a/tests/generate/test_gen_helper.py
+++ b/tests/generate/test_gen_helper.py
@@ -20,3 +20,27 @@ def test_is_valid():
         }
     })
     assert is_valid(Task(data, valid)) == True
+
+    data = Data(fields=[Field('n1', 'string'), Field('q1', 'number'), Field('q2', 'number')])
+
+    stack_color = Query.from_vegalite({
+        'mark': 'bar',
+        'encoding': {
+            'x': {
+                'type': 'nominal',
+                'field': 'n1',
+            },
+            'y': {
+                'type': 'quantitative',
+                'field': 'q1',
+                'stack': 'zero',
+                'aggregate': 'sum'
+            },
+            'color': {
+                'type': 'quantitative',
+                'field': 'q2'
+            }
+        }
+    })
+
+    assert is_valid(Task(data, stack_color), debug=True) == True


### PR DESCRIPTION
`Query.from_vegalite` was modifying the input (resulted redundant / extraneous properties during generation)