### PR TITLE
deepcopy spec in `from_vegalite` to avoid modifying input spec

### DIFF
--- a/draco/spec.py
+++ b/draco/spec.py
@@ -6,6 +6,7 @@ import json
 import os
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from copy import deepcopy
 
 import agate
 import numpy as np
@@ -481,6 +482,8 @@ class Query():
     @staticmethod
     def from_vegalite(full_spec: Dict) -> 'Query':
         ''' Parse from Vega-Lite spec that uses map for encoding. '''
+        full_spec = deepcopy(full_spec)
+
         encodings: List[Encoding] = []
 
         for channel, enc in full_spec.get('encoding', {}).items():


### PR DESCRIPTION
Query.from_vegalite was modifying the input (resulted redundant / extraneous properties during generation)